### PR TITLE
(#22) Style: header 컴포넌트 markup 

### DIFF
--- a/public/components/header.js
+++ b/public/components/header.js
@@ -1,5 +1,4 @@
 import Component from '../core/component.js';
-// import _ from '../utils/dom.js';
 import './header.scss';
 
 export default class Header extends Component {
@@ -13,7 +12,8 @@ export default class Header extends Component {
         <div class="header-right">
           ${renderHeaderMenu(type)}
         </div>
-      </div>`;
+      </div>
+      `;
   }
 
   setEventListener () {
@@ -23,22 +23,22 @@ export default class Header extends Component {
 
 const renderHeaderLeft = (type) => {
   if (type !== 'main') {
-    return '<div>뒤</div>';
+    return '<div class="wmi-chevron-left"></div>';
   }
-  return '<div>네모</div>';
+  return '<div class="wmi-category"></div>';
 };
 
 const renderHeaderMenu = (type) => {
   if (!type) return '';
 
   switch (type) {
-  case 'main':
-    return '<div>사람</div><div>햄</div>';
-  case 'write':
-    return '<div>쳌</div>';
-  case 'detail':
-    return '<div>...</div>';
-  default :
-    return '';
+    case 'main':
+      return '<div class="wmi-user"></div><div class="wmi-menu"></div>';
+    case 'write':
+      return '<div class="wmi-check"></div>';
+    case 'detail':
+      return '<div class="wmi-more-vertical"></div>';
+    default :
+      return '';
   }
 };

--- a/public/components/header.scss
+++ b/public/components/header.scss
@@ -1,3 +1,5 @@
+@import '../assets/woowa-market-icons.css';
+
 .header {
   display:flex;
   justify-content: space-between;


### PR DESCRIPTION
#22

## 개요

- Header 컴포넌트의 props에 따라 HTML 마크업 구분


## 변경사항


## 참고사항

- Header class가 전달 받는 props 

|key | type | value |
|--|--|--|
| type | string | 'main', 'write', 'detail'. 그 외에는 생략할 것 |
| title | string | 해당 페이지 타이틀 ex) 글쓰기 |

## 추가 구현 필요사항

-  #47 에서 적용한 아이콘으로 렌더링 대체 (현재는 더미 한글)
- 마크업 외의 모든 기능 (드롭다운 오픈, 뒤로가기, 글쓰기 완료 등등..)

## 스크린샷

<img width="584" alt="스크린샷 2021-07-16 오후 12 51 27" src="https://user-images.githubusercontent.com/41738385/125889263-9f584304-a93a-4a73-8768-ace2a45376f8.png">


<img width="606" alt="스크린샷 2021-07-16 오후 12 53 44" src="https://user-images.githubusercontent.com/41738385/125889333-64fbb610-302c-4808-a49d-14045680f69d.png">
