### PR TITLE
(#22) Feat : Header 컴포넌트에서 각종 아이콘 클릭시 함수 호출 로직 구현

### DIFF
--- a/public/components/header.js
+++ b/public/components/header.js
@@ -18,7 +18,7 @@ export default class Header extends Component {
   }
 
   setEventListener () {
-    const { type, backToPrevPage, handlerClickRightIcon } = this.props;
+    const { type, handlerClickRightIcon, hideSubPageBySlide } = this.props;
 
     const $left = _.$('.header__left-box');
     if (type && !['main', 'write', 'detail', 'chat'].includes(type)) {
@@ -37,12 +37,10 @@ export default class Header extends Component {
     }
 
     $left.addEventListener('click', () => {
-      if (backToPrevPage) {
-        // history 직전 페이지가 아닌 다른 곳을 원할 때 or 클라이언트 사이드
-        backToPrevPage();
+      if (hideSubPageBySlide) {
+        hideSubPageBySlide();
         return;
       }
-      // history에 남아있는 직전 페이지로 서버에 리다이렉트 요청
       moveToPrevPage();
     });
   }
@@ -74,7 +72,7 @@ export default class Header extends Component {
 }
 
 const moveToPrevPage = () => {
-  console.log('직전 페이지로');
+  window.history.back();
 };
 
 const renderHeaderLeft = (type) => {

--- a/public/components/header.js
+++ b/public/components/header.js
@@ -21,7 +21,7 @@ export default class Header extends Component {
     const { type, backToPrevPage, handlerClickRightIcon } = this.props;
 
     const $left = _.$('.header__left-box');
-    if (!['main', 'write', 'detail', 'chat'].includes(type)) {
+    if (type && !['main', 'write', 'detail', 'chat'].includes(type)) {
       throw new Error('정확한 타입 지정 & 아예 쓰지 말 것');
     }
 

--- a/public/components/header.js
+++ b/public/components/header.js
@@ -8,9 +8,9 @@ export default class Header extends Component {
 
     return `
       <div class="header ${type}">
-        <div class="header-left">${renderHeaderLeft(type)}</div>
-        <div class="header-center">${title}</div>
-        <div class="header-right">
+        <div class="header__left-box">${renderHeaderLeft(type)}</div>
+        <div class="header__title">${title}</div>
+        <div class="header__right-box">
           ${renderHeaderRight(type)}
         </div>
       </div>
@@ -20,7 +20,7 @@ export default class Header extends Component {
   setEventListener () {
     const { type, backToPrevPage } = this.props;
 
-    const $left = _.$('.header-left');
+    const $left = _.$('.header__left-box');
     if (!['main', 'write', 'detail', 'chat'].includes(type)) {
       throw new Error('정확한 타입 지정 & 아예 쓰지 말 것');
     }
@@ -48,31 +48,33 @@ export default class Header extends Component {
     const { showLocation } = this;
     const { showSubPageBySlide } = this.props;
 
-    _.$('.header-left').addEventListener('click', () => {
+    _.$('.header__left-box').addEventListener('click', () => {
       showSubPageBySlide('category');
     });
-    _.$('.header-center').addEventListener('click', showLocation);
-    _.$('.header-my-account').addEventListener('click', () => {
+    _.$('.header__title').addEventListener('click', showLocation);
+    _.$('.header__my-account').addEventListener('click', () => {
       showSubPageBySlide('myAccount');
     });
-    _.$('.header-menu').addEventListener('click', () => {
+    _.$('.header__menu').addEventListener('click', () => {
       showSubPageBySlide('myMenu');
     });
   }
 
   setRightIconHandler (handler) {
     const { type } = this.props;
-    const $rightIcon = _.$('.header-right > div');
+    const $rightIcon = _.$('.header__right-box > div');
     $rightIcon.addEventListener('click', () => {
       switch (type) {
         case 'write':
           console.log('글 쓰기');
           break;
         case 'detail':
-          console.log('수정/삭제 드롭박스 열기');
+          console.log('수정/삭제 드롭박스 생성');
+          // new DropDown($rightIcon, {});
           break;
         case 'chat':
-          console.log('나가기 확인 모달');
+          console.log('나가기 확인 모달 생성');
+          // new Modal($rightIcon, {})
           break;
         default:
           return new Error('잘못된 타입');
@@ -101,7 +103,7 @@ const renderHeaderRight = (type) => {
 
   switch (type) {
     case 'main':
-      return '<div class="wmi-user header-my-account"></div><div class="wmi-menu header-menu"></div>';
+      return '<div class="wmi-user header__my-account"></div><div class="wmi-menu header__menu"></div>';
     case 'write':
       return '<div class="wmi-check"></div>';
     case 'detail':

--- a/public/components/header.js
+++ b/public/components/header.js
@@ -11,32 +11,19 @@ export default class Header extends Component {
         <div class="header-left">${renderHeaderLeft(type)}</div>
         <div class="header-center">${title}</div>
         <div class="header-right">
-          ${renderHeaderMenu(type)}
+          ${renderHeaderRight(type)}
         </div>
       </div>
       `;
   }
 
   setEventListener () {
-    const { showLocation } = this;
-    const { type, showSubPageBySlide, backToPrevPage } = this.props;
+    const { type, backToPrevPage } = this.props;
 
     const $left = _.$('.header-left');
 
     if (type === 'main') {
-      $left.addEventListener('click', () => {
-        showSubPageBySlide('category');
-      });
-
-      _.$('.header-center').addEventListener('click', showLocation);
-
-      _.$('.header-my-account').addEventListener('click', () => {
-        showSubPageBySlide('myAccount');
-      });
-
-      _.$('.header-menu').addEventListener('click', () => {
-        showSubPageBySlide('myMenu');
-      });
+      this.setMainHeaderHandler();
       return;
     }
 
@@ -48,6 +35,22 @@ export default class Header extends Component {
       }
       // history에 남아있는 직전 페이지로 서버에 리다이렉트 요청
       moveToPrevPage();
+    });
+  }
+
+  setMainHeaderHandler () {
+    const { showLocation } = this;
+    const { showSubPageBySlide } = this.props;
+
+    _.$('.header-left').addEventListener('click', () => {
+      showSubPageBySlide('category');
+    });
+    _.$('.header-center').addEventListener('click', showLocation);
+    _.$('.header-my-account').addEventListener('click', () => {
+      showSubPageBySlide('myAccount');
+    });
+    _.$('.header-menu').addEventListener('click', () => {
+      showSubPageBySlide('myMenu');
     });
   }
 
@@ -67,7 +70,7 @@ const renderHeaderLeft = (type) => {
   return '<div class="wmi-category"></div>';
 };
 
-const renderHeaderMenu = (type) => {
+const renderHeaderRight = (type) => {
   if (!type) return '';
 
   switch (type) {
@@ -77,6 +80,8 @@ const renderHeaderMenu = (type) => {
       return '<div class="wmi-check"></div>';
     case 'detail':
       return '<div class="wmi-more-vertical"></div>';
+    case 'chat':
+      return '<div class="wmi-log-out"></div>';
     default :
       return '';
   }

--- a/public/components/header.js
+++ b/public/components/header.js
@@ -18,6 +18,7 @@ export default class Header extends Component {
   }
 
   setEventListener () {
+    const { showLocation } = this;
     const { type, showSubPageBySlide, backToPrevPage } = this.props;
 
     const $left = _.$('.header-left');
@@ -25,6 +26,16 @@ export default class Header extends Component {
     if (type === 'main') {
       $left.addEventListener('click', () => {
         showSubPageBySlide('category');
+      });
+
+      _.$('.header-center').addEventListener('click', showLocation);
+
+      _.$('.header-my-account').addEventListener('click', () => {
+        showSubPageBySlide('myAccount');
+      });
+
+      _.$('.header-menu').addEventListener('click', () => {
+        showSubPageBySlide('myMenu');
       });
       return;
     }
@@ -38,6 +49,10 @@ export default class Header extends Component {
       // history에 남아있는 직전 페이지로 서버에 리다이렉트 요청
       moveToPrevPage();
     });
+  }
+
+  showLocation () {
+    console.log('동네 보여주기');
   }
 }
 
@@ -57,7 +72,7 @@ const renderHeaderMenu = (type) => {
 
   switch (type) {
     case 'main':
-      return '<div class="wmi-user"></div><div class="wmi-menu"></div>';
+      return '<div class="wmi-user header-my-account"></div><div class="wmi-menu header-menu"></div>';
     case 'write':
       return '<div class="wmi-check"></div>';
     case 'detail':

--- a/public/components/header.js
+++ b/public/components/header.js
@@ -18,7 +18,7 @@ export default class Header extends Component {
   }
 
   setEventListener () {
-    const { type, backToPrevPage } = this.props;
+    const { type, backToPrevPage, handlerClickRightIcon } = this.props;
 
     const $left = _.$('.header__left-box');
     if (!['main', 'write', 'detail', 'chat'].includes(type)) {
@@ -29,8 +29,11 @@ export default class Header extends Component {
       this.setMainHeaderHandler();
       return;
     }
-    if (type) {
-      this.setRightIconHandler(type);
+    if (handlerClickRightIcon) {
+      if (!['write', 'detail', 'chat'].includes(type)) {
+        throw new Error('우측 아이콘 핸들러는 write, detail, chat 중 하나의 타입에서만 가능합니다.');
+      }
+      this.setRightIconHandler(handlerClickRightIcon);
     }
 
     $left.addEventListener('click', () => {
@@ -61,25 +64,8 @@ export default class Header extends Component {
   }
 
   setRightIconHandler (handler) {
-    const { type } = this.props;
     const $rightIcon = _.$('.header__right-box > div');
-    $rightIcon.addEventListener('click', () => {
-      switch (type) {
-        case 'write':
-          console.log('글 쓰기');
-          break;
-        case 'detail':
-          console.log('수정/삭제 드롭박스 생성');
-          // new DropDown($rightIcon, {});
-          break;
-        case 'chat':
-          console.log('나가기 확인 모달 생성');
-          // new Modal($rightIcon, {})
-          break;
-        default:
-          return new Error('잘못된 타입');
-      }
-    });
+    $rightIcon.addEventListener('click', handler);
   }
 
   showLocation () {

--- a/public/components/header.js
+++ b/public/components/header.js
@@ -21,10 +21,16 @@ export default class Header extends Component {
     const { type, backToPrevPage } = this.props;
 
     const $left = _.$('.header-left');
+    if (!['main', 'write', 'detail', 'chat'].includes(type)) {
+      throw new Error('정확한 타입 지정 & 아예 쓰지 말 것');
+    }
 
     if (type === 'main') {
       this.setMainHeaderHandler();
       return;
+    }
+    if (type) {
+      this.setRightIconHandler(type);
     }
 
     $left.addEventListener('click', () => {
@@ -51,6 +57,26 @@ export default class Header extends Component {
     });
     _.$('.header-menu').addEventListener('click', () => {
       showSubPageBySlide('myMenu');
+    });
+  }
+
+  setRightIconHandler (handler) {
+    const { type } = this.props;
+    const $rightIcon = _.$('.header-right > div');
+    $rightIcon.addEventListener('click', () => {
+      switch (type) {
+        case 'write':
+          console.log('글 쓰기');
+          break;
+        case 'detail':
+          console.log('수정/삭제 드롭박스 열기');
+          break;
+        case 'chat':
+          console.log('나가기 확인 모달');
+          break;
+        default:
+          return new Error('잘못된 타입');
+      }
     });
   }
 

--- a/public/components/header.js
+++ b/public/components/header.js
@@ -1,4 +1,5 @@
 import Component from '../core/component.js';
+import _ from '../utils/dom.js';
 import './header.scss';
 
 export default class Header extends Component {
@@ -17,9 +18,32 @@ export default class Header extends Component {
   }
 
   setEventListener () {
+    const { type, showSubPageBySlide, backToPrevPage } = this.props;
 
+    const $left = _.$('.header-left');
+
+    if (type === 'main') {
+      $left.addEventListener('click', () => {
+        showSubPageBySlide('category');
+      });
+      return;
+    }
+
+    $left.addEventListener('click', () => {
+      if (backToPrevPage) {
+        // history 직전 페이지가 아닌 다른 곳을 원할 때 or 클라이언트 사이드
+        backToPrevPage();
+        return;
+      }
+      // history에 남아있는 직전 페이지로 서버에 리다이렉트 요청
+      moveToPrevPage();
+    });
   }
 }
+
+const moveToPrevPage = () => {
+  console.log('직전 페이지로');
+};
 
 const renderHeaderLeft = (type) => {
   if (type !== 'main') {

--- a/public/components/header.scss
+++ b/public/components/header.scss
@@ -18,12 +18,12 @@
   }
 }
 
-.header-center {
+.header__title {
   display: flex;
   justify-content: center;
 }
 
-.header-right {
+.header__right-box {
   display: flex;
   justify-content: flex-end;
   & > div + div {


### PR DESCRIPTION
#22

## 개요

- Header 컴포넌트 함수 호출 로직 구현

## 변경사항

- chat 페이지의 우측 버튼 마크업 추가
- 헤더의 각 클릭 가능 요소에 대한 함수 호출 로직 구현

## 참고사항

## 추가 구현 필요사항

- 모달, 드롭박스 호출 함수를 외부에서 받을 것인가 / 자체에서 헤더의 자식으로 생성할 것인가.

## 스크린샷
