### PR TITLE
(#31) 슬라이더의 헤더 생성 책임 제거, 위임

### DIFF
--- a/public/components/slider.js
+++ b/public/components/slider.js
@@ -1,6 +1,5 @@
 import Component from '../core/component.js';
 import _ from '../utils/dom.js';
-import Header from './header.js';
 import './slider.scss';
 
 export default class Slider extends Component {
@@ -9,24 +8,14 @@ export default class Slider extends Component {
 
     return `
       <div class="slider__container ${sliderState}">
-        <header class="slider__header"></header>
-        <div class="slider__contents"></div>
       </div>
     `;
   }
 
   mountChildren () {
-    const { closeSlider, Constructor, title } = this.props;
+    const { Constructor, innerProps } = this.props;
 
-    const $header = _.$('.slider__header');
-    const $container = _.$('.slider__contents');
-
-    new Header($header, { title, closeSlider });
-
-    new Constructor($container, {});
-  }
-
-  setEventListener () {
-
+    const $container = _.$('.slider__container');
+    new Constructor($container, innerProps);
   }
 }

--- a/public/pages/main/style.scss
+++ b/public/pages/main/style.scss
@@ -10,4 +10,5 @@
 
 #main__slider {
   position: absolute;
+  width: 100%;
 }


### PR DESCRIPTION
#31 

## 개요

- 슬라이더 내부 헤더/컨텐츠 로직 변경

## 변경사항

- 기존 슬라이더 내부의 헤더/컨텐츠를 모두 슬라이더가 생성했지만, 헤더의 생성 책임을 컨텐츠가 하도록 변경
- 따라서 슬라이더는 컨텐츠의 헤더에 필요한 속성, 메소드 등을 부모로부터 innerProps 형태로 전달받아 컨텐츠 생성 class에게 다시 전달함

## 참고사항

- 슬라이더 내부 페이지 구현시 props로 전달받는 innerprops를 확인하고 사용하는 로직을 구현해야 한다.

- main 페이지의 scss에 있는 슬라이더 부모 돔에 width: 100%를 적용함. 

## 추가 구현 필요사항

## 스크린샷
