### PR TITLE
(#13) 카테고리 화면 뒤로가기

### DIFF
--- a/public/components/slider.js
+++ b/public/components/slider.js
@@ -1,6 +1,5 @@
 import Component from '../core/component.js';
 import _ from '../utils/dom.js';
-import Header from './header.js';
 import './slider.scss';
 
 export default class Slider extends Component {
@@ -9,24 +8,14 @@ export default class Slider extends Component {
 
     return `
       <div class="slider__container ${sliderState}">
-        <header class="slider__header"></header>
-        <div class="slider__contents"></div>
       </div>
     `;
   }
 
   mountChildren () {
-    const { closeSlider, Constructor, title } = this.props;
+    const { Constructor, innerProps } = this.props;
 
-    const $header = _.$('.slider__header');
-    const $container = _.$('.slider__contents');
-
-    new Header($header, { title, closeSlider });
-
-    new Constructor($container, {});
-  }
-
-  setEventListener () {
-
+    const $container = _.$('.slider__container');
+    new Constructor($container, innerProps);
   }
 }

--- a/public/pages/main/category/index.js
+++ b/public/pages/main/category/index.js
@@ -1,12 +1,13 @@
 import Component from '../../../core/component.js';
-
+import Header from '../../../components/header.js';
 import { categoryList } from '../../../configs/constants.js';
-
+import _ from '../../../utils/dom.js';
 import './style.scss';
 
 export default class Category extends Component {
   getTemplate () {
     return `
+      <header id="category__header"></header>
       <div class="category__content">
         ${
           categoryList.map((category) => {
@@ -23,6 +24,12 @@ export default class Category extends Component {
         }
       </div>
     `;
+  }
+
+  mountChildren () {
+    const { closeSlider } = this.props;
+    const $header = _.$('#category__header');
+    new Header($header, { title: '카테고리', closeSlider });
   }
 
   setEventListener () {

--- a/public/pages/main/style.scss
+++ b/public/pages/main/style.scss
@@ -10,4 +10,5 @@
 
 #main__slider {
   position: absolute;
+  width: 100%;
 }


### PR DESCRIPTION
#13

## 개요

- 뒤로가기 슬라이딩 

## 변경사항

- 내부 getTemplate 
- 페이지 내에서 Header 생성

## 참고사항

## 추가 구현 필요사항

- 카테고리 클릭시 해당 카테고리로 필터링 된 아이템리스트 서버에 요청

## 스크린샷
