### PR TITLE
(#12) 로그인 페이지 회원가입 이동 버그 해결

### DIFF
--- a/public/components/slider.js
+++ b/public/components/slider.js
@@ -23,7 +23,7 @@ export default class Slider extends Component {
     const { Constructor } = this.state;
     const { innerProps } = this.props;
 
-    innerProps.changeInnerContent = this.changeInnerContent;
+    innerProps.changeInnerContent = this.changeInnerContent.bind(this);
 
     const $container = _.$('.slider__container');
     new Constructor($container, innerProps);
@@ -31,6 +31,8 @@ export default class Slider extends Component {
 
   // custom
   changeInnerContent (Constructor) {
-    this.setState({ Constructor });
+    return () => {
+      this.setState({ Constructor });
+    };
   }
 }

--- a/public/pages/main/index.js
+++ b/public/pages/main/index.js
@@ -105,12 +105,6 @@ class App extends Component {
   removeSlider () {
     this.setState({ sliderState: 'none' });
   }
-
-  closeSlider () {
-    return () => {
-      this.setState({ sliderState: 'close' });
-    };
-  }
 }
 
 new App($root);

--- a/public/pages/main/login/index.js
+++ b/public/pages/main/login/index.js
@@ -48,7 +48,7 @@ export default class Login extends Component {
     const { changeInnerContent } = this.props;
 
     this.addEventListener('click', '#submit', this.handleSubmit.bind(this));
-    this.addEventListener('click', '#register', changeInnerContent.bind(this, Register));
+    this.addEventListener('click', '#register', changeInnerContent(Register));
   }
 
   // custom method


### PR DESCRIPTION
#12 

## 개요
메인 페이지 로그인 화면 회원가입으로 이동 안되는  버그 수정

## 변경사항
* `changeInnerContent`를 `Slider`에 `bind`

## 참고사항

## 추가 구현 필요사항

## 스크린샷
