### PR TITLE
(#32) fix: 세미 프레임워크 didMount 무한 루프 문제 해결.

### DIFF
--- a/client/public/core/Component.js
+++ b/client/public/core/Component.js
@@ -21,9 +21,9 @@ export default class Component {
 
   didMount () {}
 
-  setState (newState) {
+  setState (newState, isFromDidMount = false) {
     this.state = { ...this.state, ...newState };
-    this._render();
+    this._render(isFromDidMount);
   }
 
   addEventListener (eventType, selector, callback) {
@@ -41,13 +41,15 @@ export default class Component {
     this.setEventListener();
   }
 
-  _render () {
+  _render (isFromDidMount) {
     this.$target.innerHTML = '';
     this.$self = document.createElement('div');
     this.$target.append(this.$self);
     this.$self.outerHTML = this.getTemplate();
     this.mountChildren();
-    this.didMount();
+    if (!isFromDidMount) {
+      this.didMount();
+    }
   }
 
   _isTarget (target, children, selector) {


### PR DESCRIPTION
> didMount 내부에서 사용하는 setState는 두 번째 인수로 true를 전달할 것

#32

## 개요

- 비동기 요청을 위한 didMount 무한루프 문제가 발생하여 이를 해결함 

## 변경사항

- setState 메소드에 두 번째 인자로 isFromDidMount를 추가

## 참고사항

- 이 값은 기본 false이며, 보통 사용할 때는 무시하면 됨
- 다만 didMount내에서 this.state를 사용할 때에는 true값을 전달해서  _render 메소드 내에서 다시 didMount가 실행되는 것을 막음 

## 추가 구현 필요사항

- 임시방편인 방법으로, 여유가 된다면 diff 알고리즘을 작성해서 `didMount 이전 / 이후 상태값이 변했는지`를 판단해서 리렌더를 트리거하도록 수정 

## 스크린샷
