### PR TITLE
(#89) API HEAD /auth

### DIFF
--- a/api/routes/auth/head.js
+++ b/api/routes/auth/head.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import errorGenerator from '../../utils/errorGenerator.js';
+
+const router = express.Router();
+
+router.head('/', async (req, res, next) => {
+  try {
+    const token = req.headers.authorization.split('Bearer ')[1];
+
+    jwt.verify(token, process.env.ACCESS_TOKEN_SECRET, (err) => {
+      if (err) {
+        switch (err.name) {
+          case 'ToeknExpiredeError':
+            throw errorGenerator(
+              err.message,
+              'auth/token-expired'
+            );
+          case 'JsonWebTokenError':
+            throw errorGenerator(
+              err.message,
+              'auth/invalid-token'
+            );
+          default:
+            throw errorGenerator(
+              err.message,
+              'auth/invalid-token'
+            );
+        }
+      }
+    });
+
+    res.status(200).json({});
+  } catch (err) {
+    console.log(err.code);
+    switch (err.code) {
+      case 'auth/token-expired':
+        res.status(403).json({});
+        break;
+      case 'auth/invalid-token':
+        res.status(401).json({});
+        break;
+      default:
+        res.status(500).json({});
+    }
+  }
+});
+
+export default router;

--- a/api/routes/auth/towns/get.js
+++ b/api/routes/auth/towns/get.js
@@ -1,0 +1,55 @@
+import express from 'express';
+
+import pool, { queryAll } from '../../../model/db.js';
+import validateAuth from '../../../middlewares/validateAuth.js';
+import { decodeToken } from '../../../utils/jwt.js';
+
+const router = express.Router();
+
+router.get('/', validateAuth, async (req, res, next) => {
+  try {
+    const token = req.headers.authorization.split('Bearer ')[1];
+    const { uid } = decodeToken(token);
+
+    const connection = await pool.getConnection(async conn => conn);
+
+    const GET_TOWN_QUERY = `
+      SELECT
+        TOWN_LIST.TOWN_ID AS id,
+        TOWN_LIST.is_active AS isActive,
+        TOWN.name AS name
+      FROM TOWN_LIST
+      LEFT JOIN TOWN
+        ON TOWN_LIST.TOWN_ID = TOWN.ID
+      WHERE TOWN_LIST.USER_UID = '${uid}'
+    `;
+
+    const userSnapshot = await queryAll(connection, GET_TOWN_QUERY);
+
+    const towns = [];
+
+    userSnapshot.data.forEach((town, i) => {
+      const { id, name, isActive } = town;
+
+      towns.push({
+        id,
+        name,
+        isActive
+      });
+    });
+
+    res.status(200).json({
+      towns
+    });
+  } catch (err) {
+    console.log(err);
+    switch (err.code) {
+      default:
+        res.status(500).json({
+          message: '다시 시도해주세요'
+        });
+    }
+  }
+});
+
+export default router;


### PR DESCRIPTION
#89 

## 개요
로그인되어 가지고 있는 토큰의 유효성 검사를 위한 API

## 변경사항
* `HEAD` `/auth` API 추가

## 참고사항
* `HEAD` 메소드라 `statusCode`로 구분
  * `200`: 유효한 토큰
  * `401`: 유효하지 않은 토큰. 토큰을 지우고 로그인 페이지로 이동
  * `500`: 서버 에러. 재시도 필요

## 추가 구현 필요사항

## 스크린샷
